### PR TITLE
Add GaussianMLP and GaussianMLPEnsemble

### DIFF
--- a/fusion_transport_surrogates/networks.py
+++ b/fusion_transport_surrogates/networks.py
@@ -100,9 +100,9 @@ class GaussianMLPEnsemble(nn.Module):
       ],
       axis=0,
     )
-    mean = jnp.mean(ensemble_output[..., 0], axis=-1)
-    aleatoric = jnp.mean(ensemble_output[..., 1], axis=-1)
-    epistemic = jnp.var(ensemble_output[..., 0], axis=-1)
+    mean = jnp.mean(ensemble_output[..., 0], axis=0)
+    aleatoric = jnp.mean(ensemble_output[..., 1], axis=0)
+    epistemic = jnp.var(ensemble_output[..., 0], axis=0)
     return jnp.stack([mean, aleatoric + epistemic], axis=-1)
 
 

--- a/fusion_transport_surrogates/networks.py
+++ b/fusion_transport_surrogates/networks.py
@@ -50,6 +50,62 @@ class MLP(nn.Module):
     return x
 
 
+class GaussianMLP(nn.Module):
+  """An MLP with dropout, outputting a mean and variance."""
+
+  num_hiddens: int
+  hidden_size: int
+  dropout: float
+  activation: str
+
+  @nn.compact
+  def __call__(
+      self,
+      x,
+      deterministic: bool = False,
+  ):
+    for _ in range(self.num_hiddens - 1):
+      x = nn.Dense(self.hidden_size)(x)
+      x = nn.Dropout(rate=self.dropout, deterministic=deterministic)(x)
+      x = _ACTIVATION_FNS[self.activation](x)
+    mean_and_var = nn.Dense(2)(x)
+    mean = mean_and_var[..., 0]
+    var = mean_and_var[..., 1]
+    var = nn.softplus(var)
+
+    return jnp.stack([mean, var], axis=-1)
+
+
+class GaussianMLPEnsemble(nn.Module):
+  """An ensemble of GaussianMLPs."""
+
+  n_ensemble: int
+  num_hiddens: int
+  hidden_size: int
+  dropout: float
+  activation: str
+
+  @nn.compact
+  def __call__(
+    self,
+    x,
+    deterministic: bool = False,
+  ):
+    ensemble_output = jnp.stack(
+      [
+        GaussianMLP(
+          self.num_hiddens, self.hidden_size, self.dropout, self.activation
+        )(x, deterministic=deterministic)
+        for _ in range(self.n_ensemble)
+      ],
+      axis=0,
+    )
+    mean = jnp.mean(ensemble_output[..., 0], axis=-1)
+    aleatoric = jnp.mean(ensemble_output[..., 1], axis=-1)
+    epistemic = jnp.var(ensemble_output[..., 0], axis=-1)
+    return jnp.stack([mean, aleatoric + epistemic], axis=-1)
+
+
 class DisjointMLPs(nn.Module):
   """Disjoint MLPs, one per target."""
 
@@ -222,16 +278,20 @@ class CGMNets(nn.Module):
 
 class NetworkType(enum.Enum):
   MLP = 'mlp'
+  GAUSSIAN_MLP = 'gaussian_mlp'
   DISJOINT_MLPS = 'disjoint_mlps'
   MODE_MLPS = 'mode_mlps'
+  GAUSSIAN_MLP_ENSEMBLE = 'gaussian_mlp_ensemble'
   CGM = 'cgm'
 
 
 NETWORK_MAP: Final[Mapping[NetworkType, type[nn.Module]]] = (
     immutabledict.immutabledict({
         NetworkType.MLP: MLP,
+        NetworkType.GAUSSIAN_MLP: GaussianMLP,
         NetworkType.DISJOINT_MLPS: DisjointMLPs,
         NetworkType.MODE_MLPS: ModeMLPs,
+        NetworkType.GAUSSIAN_MLP_ENSEMBLE: GaussianMLPEnsemble,
         NetworkType.CGM: CGMNets,
     })
 )

--- a/fusion_transport_surrogates/networks_test.py
+++ b/fusion_transport_surrogates/networks_test.py
@@ -22,7 +22,7 @@ import jax.numpy as jnp
 class NetworksTest(absltest.TestCase):
 
   def _test_network_io(
-      self, network: nn.Module, num_inputs: int, num_targets: int
+      self, network: nn.Module, num_inputs: int, num_targets: int, **kwargs
   ):
     """Checks that the network inputs and outputs have the correct shapes."""
     # Initialize the parameters
@@ -34,7 +34,7 @@ class NetworksTest(absltest.TestCase):
 
     # Apply the network to some input data
     inputs = jnp.ones((batch_size, num_inputs))
-    outputs = network.apply(params, inputs)
+    outputs = network.apply(params, inputs, **kwargs)
     # Check the shape of the outputs
     self.assertEqual(outputs.shape, (batch_size, num_targets))
 
@@ -62,6 +62,33 @@ class NetworksTest(absltest.TestCase):
     )
     self._test_network_io(network, num_inputs, hidden_size)
 
+  def test_gaussian_mlp(self):
+    num_inputs = 5
+    num_targets = 2 # Gaussian MLPs always have 2 outputs.
+
+    network = networks.NETWORK_MAP[networks.NetworkType.GAUSSIAN_MLP](
+        num_hiddens=2,
+        hidden_size=7,
+        dropout=0.1,
+        activation='relu',
+    )
+    self._test_network_io(network, num_inputs, num_targets, deterministic=True)
+    
+  def test_gaussian_mlp_ensemble(self):
+    num_inputs = 5
+    num_targets = 2 # Gaussian MLPs always have 2 outputs.
+    n_ensemble = 3
+    
+    network = networks.NETWORK_MAP[networks.NetworkType.GAUSSIAN_MLP_ENSEMBLE](
+        num_hiddens=2,
+        hidden_size=7,
+        dropout=0.1,
+        activation='relu',
+        n_ensemble=n_ensemble,
+    )
+    
+    self._test_network_io(network, num_inputs, num_targets, deterministic=True)      
+      
   def test_disjoint_mlps(self):
     num_inputs = 5
     num_targets = 5


### PR DESCRIPTION
UKAEA-STEP-TGLFNN uses MLPs with Gaussian outputs (mean and variance) as well as an ensemble of MLP models. This PR adds the appropriate model architecture and unit tests.